### PR TITLE
fix: passing version from version tag

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,8 @@ builds:
     binary: aws-iam-user
     goos: ["linux", "darwin", "windows"]
     goarch: ["386", "amd64", "arm64"]
+    ldflags:
+      - -s -w -X "main.version={{.Version}}"
     env:
       - CGO_ENABLED=0
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/conijnio/aws-iam-user/cmd"
+import (
+	"github.com/conijnio/aws-iam-user/cmd"
+)
 
 var (
 	version = "dev"


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

By using the version tags we can choice when to build a new release. However the `ldflags` where not passed correctly.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [ ] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
